### PR TITLE
fix bug caused by improper version of rubyzip

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ burr 是一个 Ruby gem，可以像其他 gem 一样安装。但是由于没有�
 在项目的 `Gemfile` 中加入以下代码：
 
 ```ruby
-gem 'burr'
+gem 'burr', git:'git@github.com:AndorChen/burr.git'
 ```
 
 然后执行 `bundle` 命令安装。

--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ gem 'burr', git:'git@github.com:AndorChen/burr.git'
      |- code/
 ```
 
+### 安装gem
+
+在项目的Gemfile中增加:
+
+```ruby
+gem 'rubyzip', '< 1.0.0'
+```
+
+执行`bundle`
+
 ### 生成电子书
 
 ```sh

--- a/burr.gemspec
+++ b/burr.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('kramdown',    '~> 1.2.0')
   s.add_runtime_dependency('pygments.rb', '~> 0.5.4')
   s.add_runtime_dependency('eeepub',      '~> 0.8.1')
+  s.add_runtime_dependency('rubyzip', '< 1.0.0')
 
   s.files = `git ls-files`.split($/)
 end


### PR DESCRIPTION
Using rubyzip 1.1.0 will cause problems like this:

``` ruby
~/.rvm/gems/ruby-2.0.0-p353@book/gems/eeepub-0.8.1/lib/eeepub/ocf.rb:1:in `require': cannot load such file -- zip/zip (LoadError)
```

and rubyzip 0.9.9 is fine~
